### PR TITLE
Better key transformation functions and 100% code coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "type": "module",
   "scripts": {
     "lint": "npx prettier . --check",
-    "test": "jest --coverage",
+    "test": "jest --coverage --verbose",
     "lint:format": "npx prettier . --write",
     "build": "npm run build:npm",
     "build:npm": "rollup -c rollup.config.ts --configPlugin typescript"

--- a/src/format.test.ts
+++ b/src/format.test.ts
@@ -1,0 +1,97 @@
+import { camelToSnake, keysToCamel, keysToSnake, snakeToCamel } from "./format";
+
+describe("snakeToCamel", () => {
+  const TEST_CASES = [
+    { input: "foo_bar_baz", expected: "fooBarBaz" },
+    { input: "foo_bar__baz", expected: "fooBarBaz" },
+    { input: "foo__bar_baz", expected: "fooBarBaz" },
+    { input: "foo__", expected: "foo" },
+    { input: "foo_", expected: "foo" },
+    { input: "__foo_", expected: "foo" },
+  ];
+
+  for (const { input, expected } of TEST_CASES) {
+    test(`${JSON.stringify(input)} -> ${JSON.stringify(expected)}`, () => {
+      expect(snakeToCamel(input)).toEqual(expected);
+    });
+  }
+});
+
+describe("camelToSnake", () => {
+  const TEST_CASES = [
+    { input: "fooBarBaz", expected: "foo_bar_baz" },
+    { input: "foo", expected: "foo" },
+  ];
+
+  for (const { input, expected } of TEST_CASES) {
+    test(`${JSON.stringify(input)} -> ${JSON.stringify(expected)}`, () => {
+      expect(camelToSnake(input)).toEqual(expected);
+    });
+  }
+});
+
+describe("keysToCamel", () => {
+  const TEST_CASES = [
+    {
+      name: "nested data",
+      input: {
+        foo_bar: "testing",
+        additional_props: {
+          test_baz: {
+            foo: [{ __foo_bar: "foo" }],
+          },
+        },
+      },
+      expected: {
+        fooBar: "testing",
+        additionalProps: {
+          testBaz: {
+            foo: [{ fooBar: "foo" }],
+          },
+        },
+      },
+    },
+  ];
+
+  for (const { name, input, expected } of TEST_CASES) {
+    test(
+      name ?? `${JSON.stringify(input)} -> ${JSON.stringify(expected)}`,
+      () => {
+        expect(keysToCamel(input)).toEqual(expected);
+      },
+    );
+  }
+});
+
+describe("keysToSnake", () => {
+  const TEST_CASES = [
+    {
+      name: "nested data",
+      input: {
+        fooBar: "testing",
+        additionalProps: {
+          testBaz: {
+            foo: [{ fooBar: "foo" }],
+          },
+        },
+      },
+      expected: {
+        foo_bar: "testing",
+        additional_props: {
+          test_baz: {
+            foo: [{ foo_bar: "foo" }],
+          },
+        },
+      },
+    },
+  ];
+
+  for (const { name, input, expected } of TEST_CASES) {
+    test(
+      name ?? `${JSON.stringify(input)} -> ${JSON.stringify(expected)}`,
+      () => {
+        expect(keysToSnake(input)).toEqual(expected);
+      },
+    );
+  }
+});

--- a/src/format.ts
+++ b/src/format.ts
@@ -11,10 +11,13 @@ export function keysToSnake<T>(obj: T): any {
   return obj;
 }
 
-export const snakeToCamel = (str: string) =>
-  str.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
+export const snakeToCamel = (str: string) => {
+  return str
+    .replace(/^_+/, "")
+    .replace(/_+([a-z])/g, (_, c) => c.toUpperCase())
+    .replace(/_+$/, "");
+};
 
-// eslint-disable-next-line  @typescript-eslint/no-explicit-any
 export function keysToCamel<T>(obj: T): any {
   if (Array.isArray(obj)) return obj.map(keysToCamel);
   if (obj !== null && typeof obj === "object") {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2,107 +2,253 @@ import z from "zod";
 import { zodToCamelCaseOutput, zodToCamelCaseInputAndOutput } from "./";
 
 describe("zodToCamelCaseOutput", () => {
-  test("nested", () => {
-    const schema = z.object({
-      key_one: z.string(),
-      key_two: z.string(),
-      additional_props: z.object({
-        foo_bar: z.number(),
-      }),
+  describe(".safeParse()", () => {
+    test("valid nested data", () => {
+      const schema = z.object({
+        key_one: z.string(),
+        key_two: z.string(),
+        additional_props: z.object({
+          foo_bar: z.number(),
+        }),
+      });
+      const camelCaseSchema = zodToCamelCaseOutput(schema);
+      const results = camelCaseSchema.safeParse({
+        key_one: "one",
+        key_two: "two",
+        additional_props: {
+          foo_bar: 4,
+        },
+      });
+      expect(results.success).toEqual(true);
+      expect(results.data).toEqual({
+        keyOne: "one",
+        keyTwo: "two",
+        additionalProps: {
+          fooBar: 4,
+        },
+      });
     });
-    const camelCaseSchema = zodToCamelCaseOutput(schema);
-    const results = camelCaseSchema.parse({
-      key_one: "one",
-      key_two: "two",
-      additional_props: {
-        foo_bar: 4,
-      },
-    });
-    expect(results).toEqual({
-      keyOne: "one",
-      keyTwo: "two",
-      additionalProps: {
-        fooBar: 4,
-      },
+
+    test("parse errors are remapped", () => {
+      const schema = z.object({
+        key_one: z.string(),
+      });
+      const camelCaseSchema = zodToCamelCaseOutput(schema);
+      const results = camelCaseSchema.safeParse({
+        // @ts-expect-error
+        key_two: "one",
+      });
+      expect(results.success).toEqual(false);
+      expect(results.error?.message).toEqual(
+        JSON.stringify(
+          [
+            {
+              expected: "string",
+              code: "invalid_type",
+              path: ["key_one"],
+              message: "Invalid input: expected string, received undefined",
+            },
+          ],
+          null,
+          2,
+        ),
+      );
     });
   });
 
-  test("error remapped", () => {
-    const schema = z.object({
-      key_one: z.string(),
+  describe(".parse()", () => {
+    test("valid nested data", () => {
+      const schema = z.object({
+        key_one: z.string(),
+        key_two: z.string(),
+        additional_props: z.object({
+          foo_bar: z.number(),
+        }),
+      });
+      const camelCaseSchema = zodToCamelCaseOutput(schema);
+      const results = camelCaseSchema.parse({
+        key_one: "one",
+        key_two: "two",
+        additional_props: {
+          foo_bar: 4,
+        },
+      });
+      expect(results).toEqual({
+        keyOne: "one",
+        keyTwo: "two",
+        additionalProps: {
+          fooBar: 4,
+        },
+      });
     });
-    const camelCaseSchema = zodToCamelCaseOutput(schema);
-    const results = camelCaseSchema.safeParse({
-      // @ts-expect-error
-      key_two: "one",
+
+    test("parse errors are remapped", () => {
+      const schema = z.object({
+        key_one: z.string(),
+      });
+      const camelCaseSchema = zodToCamelCaseOutput(schema);
+      expect(() => {
+        camelCaseSchema.parse({
+          // @ts-expect-error
+          key_two: "one",
+        });
+      }).toThrow(
+        new Error(
+          JSON.stringify(
+            [
+              {
+                expected: "string",
+                code: "invalid_type",
+                path: ["key_one"],
+                message: "Invalid input: expected string, received undefined",
+              },
+            ],
+            null,
+            2,
+          ),
+        ),
+      );
     });
-    expect(results.success).toEqual(false);
-    expect(results.error?.message).toEqual(
-      JSON.stringify(
-        [
-          {
-            expected: "string",
-            code: "invalid_type",
-            path: ["key_one"],
-            message: "Invalid input: expected string, received undefined",
-          },
-        ],
-        null,
-        2,
-      ),
-    );
+
+    test("non parse error", () => {
+      const schema = z.object({
+        key_one: z.string().transform(() => {
+          throw new Error("arrgh");
+          return "";
+        }),
+      });
+      const camelCaseSchema = zodToCamelCaseOutput(schema);
+      expect(() => {
+        camelCaseSchema.parse({
+          key_one: "one",
+        });
+      }).toThrow(new Error("arrgh"));
+    });
   });
 });
 
 describe("zodToCamelCaseInputOutput", () => {
-  test("nested", () => {
-    const schema = z.object({
-      key_one: z.string(),
-      key_two: z.string(),
-      additional_props: z.object({
-        foo_bar: z.number(),
-      }),
+  describe(".safeParse()", () => {
+    test("valid nested data", () => {
+      const schema = z.object({
+        key_one: z.string(),
+        key_two: z.string(),
+        additional_props: z.object({
+          foo_bar: z.number(),
+        }),
+      });
+      const camelCaseSchema = zodToCamelCaseInputAndOutput(schema);
+      const results = camelCaseSchema.safeParse({
+        keyOne: "one",
+        keyTwo: "two",
+        additionalProps: {
+          fooBar: 4,
+        },
+      });
+      expect(results.success).toEqual(true);
+      expect(results.data).toEqual({
+        keyOne: "one",
+        keyTwo: "two",
+        additionalProps: {
+          fooBar: 4,
+        },
+      });
     });
-    const camelCaseSchema = zodToCamelCaseInputAndOutput(schema);
-    const results = camelCaseSchema.parse({
-      keyOne: "one",
-      keyTwo: "two",
-      additionalProps: {
-        fooBar: 4,
-      },
-    });
-    expect(results).toEqual({
-      keyOne: "one",
-      keyTwo: "two",
-      additionalProps: {
-        fooBar: 4,
-      },
+
+    test("parse errors are remapped", () => {
+      const schema = z.object({
+        key_one: z.string(),
+      });
+      const camelCaseSchema = zodToCamelCaseInputAndOutput(schema);
+      const results = camelCaseSchema.safeParse({
+        // @ts-expect-error
+        keyTwo: "one",
+      });
+      expect(results.success).toEqual(false);
+      expect(results.error?.message).toEqual(
+        JSON.stringify(
+          [
+            {
+              expected: "string",
+              code: "invalid_type",
+              path: ["keyOne"],
+              message: "Invalid input: expected string, received undefined",
+            },
+          ],
+          null,
+          2,
+        ),
+      );
     });
   });
 
-  test("error remapped", () => {
-    const schema = z.object({
-      key_one: z.string(),
+  describe(".parse()", () => {
+    test("valid nested data", () => {
+      const schema = z.object({
+        key_one: z.string(),
+        key_two: z.string(),
+        additional_props: z.object({
+          foo_bar: z.number(),
+        }),
+      });
+      const camelCaseSchema = zodToCamelCaseInputAndOutput(schema);
+      const results = camelCaseSchema.parse({
+        keyOne: "one",
+        keyTwo: "two",
+        additionalProps: {
+          fooBar: 4,
+        },
+      });
+      expect(results).toEqual({
+        keyOne: "one",
+        keyTwo: "two",
+        additionalProps: {
+          fooBar: 4,
+        },
+      });
     });
-    const camelCaseSchema = zodToCamelCaseInputAndOutput(schema);
-    const results = camelCaseSchema.safeParse({
-      // @ts-expect-error
-      keyTwo: "one",
+
+    test("parse errors are remapped", () => {
+      const schema = z.object({
+        key_one: z.string(),
+      });
+      const camelCaseSchema = zodToCamelCaseInputAndOutput(schema);
+      expect(() => {
+        camelCaseSchema.parse({
+          // @ts-expect-error
+          keyTwo: "one",
+        });
+      }).toThrow(
+        new Error(
+          JSON.stringify(
+            [
+              {
+                expected: "string",
+                code: "invalid_type",
+                path: ["keyOne"],
+                message: "Invalid input: expected string, received undefined",
+              },
+            ],
+            null,
+            2,
+          ),
+        ),
+      );
     });
-    expect(results.success).toEqual(false);
-    expect(results.error?.message).toEqual(
-      JSON.stringify(
-        [
-          {
-            expected: "string",
-            code: "invalid_type",
-            path: ["keyOne"],
-            message: "Invalid input: expected string, received undefined",
-          },
-        ],
-        null,
-        2,
-      ),
-    );
+
+    test("non parse error", () => {
+      const schema = z.object({
+        key_one: z.string().transform(() => {
+          throw new Error("arrgh");
+          return "";
+        }),
+      });
+      const camelCaseSchema = zodToCamelCaseInputAndOutput(schema);
+      expect(() => {
+        camelCaseSchema.parse({
+          keyOne: "one",
+        });
+      }).toThrow(new Error("arrgh"));
+    });
   });
 });


### PR DESCRIPTION
Better key transformations

 - `foo_bar__baz` -> `fooBarBaz`
 - `__foo` -> `foo`
 - `foo__` -> `foo`

Also 100% code coverage on codebase