### PR TITLE
Rename and export format functions

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -1,10 +1,10 @@
 import z, { ZodError } from "zod";
-import { snakeToCamel } from "./format";
+import { snakeToCamelCase } from "./format";
 
 export function rewriteErrorPathsToCamel(error: ZodError<any>): ZodError<any> {
   const newIssues: z.core.$ZodIssue[] = error.issues.map((issue) => {
     const path = issue.path.map((segment) =>
-      typeof segment === "string" ? snakeToCamel(segment) : segment,
+      typeof segment === "string" ? snakeToCamelCase(segment) : segment,
     );
     return { ...issue, path };
   });

--- a/src/format.test.ts
+++ b/src/format.test.ts
@@ -1,6 +1,11 @@
-import { camelToSnake, keysToCamel, keysToSnake, snakeToCamel } from "./format";
+import {
+  camelToSnakeCase,
+  keysToCamelCase,
+  keysToSnakeCase,
+  snakeToCamelCase,
+} from "./format";
 
-describe("snakeToCamel", () => {
+describe("snakeToCamelCase", () => {
   const TEST_CASES = [
     { input: "foo_bar_baz", expected: "fooBarBaz" },
     { input: "foo_bar__baz", expected: "fooBarBaz" },
@@ -12,12 +17,12 @@ describe("snakeToCamel", () => {
 
   for (const { input, expected } of TEST_CASES) {
     test(`${JSON.stringify(input)} -> ${JSON.stringify(expected)}`, () => {
-      expect(snakeToCamel(input)).toEqual(expected);
+      expect(snakeToCamelCase(input)).toEqual(expected);
     });
   }
 });
 
-describe("camelToSnake", () => {
+describe("camelToSnakeCase", () => {
   const TEST_CASES = [
     { input: "fooBarBaz", expected: "foo_bar_baz" },
     { input: "foo", expected: "foo" },
@@ -25,12 +30,12 @@ describe("camelToSnake", () => {
 
   for (const { input, expected } of TEST_CASES) {
     test(`${JSON.stringify(input)} -> ${JSON.stringify(expected)}`, () => {
-      expect(camelToSnake(input)).toEqual(expected);
+      expect(camelToSnakeCase(input)).toEqual(expected);
     });
   }
 });
 
-describe("keysToCamel", () => {
+describe("keysToCamelCase", () => {
   const TEST_CASES = [
     {
       name: "nested data",
@@ -57,13 +62,13 @@ describe("keysToCamel", () => {
     test(
       name ?? `${JSON.stringify(input)} -> ${JSON.stringify(expected)}`,
       () => {
-        expect(keysToCamel(input)).toEqual(expected);
+        expect(keysToCamelCase(input)).toEqual(expected);
       },
     );
   }
 });
 
-describe("keysToSnake", () => {
+describe("keysToSnakeCase", () => {
   const TEST_CASES = [
     {
       name: "nested data",
@@ -90,7 +95,7 @@ describe("keysToSnake", () => {
     test(
       name ?? `${JSON.stringify(input)} -> ${JSON.stringify(expected)}`,
       () => {
-        expect(keysToSnake(input)).toEqual(expected);
+        expect(keysToSnakeCase(input)).toEqual(expected);
       },
     );
   }

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,28 +1,34 @@
-export const camelToSnake = (str: string) =>
+export const camelToSnakeCase = (str: string) =>
   str.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
 
-export function keysToSnake<T>(obj: T): any {
-  if (Array.isArray(obj)) return obj.map(keysToSnake);
+export function keysToSnakeCase<T>(obj: T): any {
+  if (Array.isArray(obj)) return obj.map(keysToSnakeCase);
   if (obj !== null && typeof obj === "object") {
     return Object.fromEntries(
-      Object.entries(obj).map(([k, v]) => [camelToSnake(k), keysToSnake(v)]),
+      Object.entries(obj).map(([k, v]) => [
+        camelToSnakeCase(k),
+        keysToSnakeCase(v),
+      ]),
     );
   }
   return obj;
 }
 
-export const snakeToCamel = (str: string) => {
+export const snakeToCamelCase = (str: string) => {
   return str
     .replace(/^_+/, "")
     .replace(/_+([a-z])/g, (_, c) => c.toUpperCase())
     .replace(/_+$/, "");
 };
 
-export function keysToCamel<T>(obj: T): any {
-  if (Array.isArray(obj)) return obj.map(keysToCamel);
+export function keysToCamelCase<T>(obj: T): any {
+  if (Array.isArray(obj)) return obj.map(keysToCamelCase);
   if (obj !== null && typeof obj === "object") {
     return Object.fromEntries(
-      Object.entries(obj).map(([k, v]) => [snakeToCamel(k), keysToCamel(v)]),
+      Object.entries(obj).map(([k, v]) => [
+        snakeToCamelCase(k),
+        keysToCamelCase(v),
+      ]),
     );
   }
   return obj;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,19 @@
 import { z, ZodError, ZodType } from "zod";
-import { keysToCamel, keysToSnake } from "./format";
+import { keysToCamelCase, keysToSnakeCase } from "./format";
 import { ZodContribKeysToCamel } from "./types";
 import { rewriteErrorPathsToCamel } from "./error";
 
+export { keysToCamelCase, keysToSnakeCase };
+
 // Fully generic reusable function with internal type mapping
 export function zodToCamelCaseOutput<T extends ZodType>(schema: T) {
-  const newSchema = schema.transform((data) => keysToCamel(data));
+  const newSchema = schema.transform((data) => keysToCamelCase(data));
   return {
     ...newSchema,
     parse(input: z.infer<T>): ZodContribKeysToCamel<z.infer<T>> {
       try {
         const parsed = newSchema.parse(input);
-        return keysToCamel(parsed) as ZodContribKeysToCamel<z.infer<T>>;
+        return keysToCamelCase(parsed) as ZodContribKeysToCamel<z.infer<T>>;
       } catch (err) {
         throw err;
       }
@@ -23,7 +25,7 @@ export function zodToCamelCaseOutput<T extends ZodType>(schema: T) {
       }
       return {
         success: true as const,
-        data: keysToCamel(result.data) as ZodContribKeysToCamel<z.infer<T>>,
+        data: keysToCamelCase(result.data) as ZodContribKeysToCamel<z.infer<T>>,
       };
     },
   };
@@ -32,8 +34,8 @@ export function zodToCamelCaseOutput<T extends ZodType>(schema: T) {
 // Fully generic reusable function with internal type mapping
 export function zodToCamelCaseInputAndOutput<T extends ZodType>(schema: T) {
   const newSchema = z
-    .preprocess((input) => keysToSnake(input as any), schema)
-    .transform((data) => keysToCamel(data));
+    .preprocess((input) => keysToSnakeCase(input as any), schema)
+    .transform((data) => keysToCamelCase(data));
   return {
     ...newSchema,
     parse(
@@ -41,7 +43,7 @@ export function zodToCamelCaseInputAndOutput<T extends ZodType>(schema: T) {
     ): ZodContribKeysToCamel<z.infer<T>> {
       try {
         const parsed = newSchema.parse(input);
-        return keysToCamel(parsed) as ZodContribKeysToCamel<z.infer<T>>;
+        return keysToCamelCase(parsed) as ZodContribKeysToCamel<z.infer<T>>;
       } catch (err) {
         if (err instanceof ZodError) throw rewriteErrorPathsToCamel(err);
         throw err;
@@ -57,7 +59,7 @@ export function zodToCamelCaseInputAndOutput<T extends ZodType>(schema: T) {
       }
       return {
         success: true as const,
-        data: keysToCamel(result.data) as ZodContribKeysToCamel<z.infer<T>>,
+        data: keysToCamelCase(result.data) as ZodContribKeysToCamel<z.infer<T>>,
       };
     },
   };


### PR DESCRIPTION
Rename and export format functions from main package, renames

 - `camelToSnake` -> `camelToSnakeCase`
 - `keysToSnake` -> `keysToSnakeCase`
 - `snakeToCamel` -> `snakeToCamelCase`
 - `keysToCamel` -> `keysToCamelCase`