### PR TITLE
Update API & fix `z.infer<T>` bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,26 +5,30 @@ Convert zod schemas to camel case keys
 > [!WARNING]
 > This is a work in progress, here be dragons 🐉
 
-Here is an example
+## Usage
+
+The `zodToCamelCase` supports both unidirectional and bidirectional transformation of schemas
+
+### `zodToCamelCase` (unidirectional)
+
+By default `zodToCamelCase` supports unidirectional transformation of the schema.
+
+So the input will be expected to in the original snake-case format. The output data/type will be camel-case.
 
 ```ts
 import { z } from "zod";
 import zodToCamelCase from "zod-to-camel-case";
 
-// Original schema
-const schema = z.object({
+const userSchemaSnake = z.object({
   full_name: z.string(),
   user: z.object({
     email_addresses: z.array(z.email()),
   }),
 });
-
-// Convert the schema
-// Note: Use `zodToCamelCaseOutput` for uni-directional
-const camelCaseSchema = zodToCamelCaseInputAndOutput(schema);
+const userSchema = zodToCamelCase(userSchemaSnake);
 
 // Infer the type using zod
-type Foo = z.infer<typeof camelCaseSchema>; /**
+type User = z.infer<typeof userSchema>; /**
  * {
  *   fullName: string;
  *   user: {
@@ -33,7 +37,59 @@ type Foo = z.infer<typeof camelCaseSchema>; /**
  * }
  */
 
-const results = camelCaseSchema.parse({
+// This input is snake-case
+const results = userSchema.parse({
+  full_name: "Turanga Leela",
+  user: {
+    email_addresses: ["name@example.com"],
+  },
+});
+
+// The output is camel-case
+assert.deepEqual(results, {
+  fullName: "Turanga Leela",
+  user: {
+    emailAddresses: ["name@example.com"],
+  },
+});
+```
+
+### `zodToCamelCase` (bidirectional)
+
+By passing `{bidirectional: true}` as a second option to `zodToCamelCase` will change the expected input to be snake-case.
+
+```ts
+import { z } from "zod";
+import zodToCamelCase from "zod-to-camel-case";
+
+const userSchemaSnake = z.object({
+  full_name: z.string(),
+  user: z.object({
+    email_addresses: z.array(z.email()),
+  }),
+});
+const userSchema = zodToCamelCase(userSchemaSnake, { bidirectional: true });
+
+// Infer the type using zod
+type User = z.infer<typeof userSchema>; /**
+ * {
+ *   fullName: string;
+ *   user: {
+ *     emailAddresses: string[];
+ *   }
+ * }
+ */
+
+// This input is snake-case
+const results = userSchema.parse({
+  fullName: "Turanga Leela",
+  user: {
+    emailAddresses: ["name@example.com"],
+  },
+});
+
+// The output is camel-case
+assert.deepEqual(results, {
   fullName: "Turanga Leela",
   user: {
     emailAddresses: ["name@example.com"],

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,5 @@
 import z from "zod";
-import { zodToCamelCaseOutput, zodToCamelCaseInputAndOutput } from "./";
+import { zodToCamelCase } from "./";
 
 describe("zodToCamelCaseOutput", () => {
   describe(".safeParse()", () => {
@@ -11,7 +11,8 @@ describe("zodToCamelCaseOutput", () => {
           foo_bar: z.number(),
         }),
       });
-      const camelCaseSchema = zodToCamelCaseOutput(schema);
+      const camelCaseSchema = zodToCamelCase(schema);
+      type Foo = z.infer<typeof camelCaseSchema>
       const results = camelCaseSchema.safeParse({
         key_one: "one",
         key_two: "two",
@@ -33,7 +34,7 @@ describe("zodToCamelCaseOutput", () => {
       const schema = z.object({
         key_one: z.string(),
       });
-      const camelCaseSchema = zodToCamelCaseOutput(schema);
+      const camelCaseSchema = zodToCamelCase(schema);
       const results = camelCaseSchema.safeParse({
         // @ts-expect-error
         key_two: "one",
@@ -65,7 +66,7 @@ describe("zodToCamelCaseOutput", () => {
           foo_bar: z.number(),
         }),
       });
-      const camelCaseSchema = zodToCamelCaseOutput(schema);
+      const camelCaseSchema = zodToCamelCase(schema);
       const results = camelCaseSchema.parse({
         key_one: "one",
         key_two: "two",
@@ -86,7 +87,7 @@ describe("zodToCamelCaseOutput", () => {
       const schema = z.object({
         key_one: z.string(),
       });
-      const camelCaseSchema = zodToCamelCaseOutput(schema);
+      const camelCaseSchema = zodToCamelCase(schema);
       expect(() => {
         camelCaseSchema.parse({
           // @ts-expect-error
@@ -117,7 +118,7 @@ describe("zodToCamelCaseOutput", () => {
           return "";
         }),
       });
-      const camelCaseSchema = zodToCamelCaseOutput(schema);
+      const camelCaseSchema = zodToCamelCase(schema);
       expect(() => {
         camelCaseSchema.parse({
           key_one: "one",
@@ -137,7 +138,7 @@ describe("zodToCamelCaseInputOutput", () => {
           foo_bar: z.number(),
         }),
       });
-      const camelCaseSchema = zodToCamelCaseInputAndOutput(schema);
+      const camelCaseSchema = zodToCamelCase(schema, {bidirectional: true});
       const results = camelCaseSchema.safeParse({
         keyOne: "one",
         keyTwo: "two",
@@ -159,7 +160,7 @@ describe("zodToCamelCaseInputOutput", () => {
       const schema = z.object({
         key_one: z.string(),
       });
-      const camelCaseSchema = zodToCamelCaseInputAndOutput(schema);
+      const camelCaseSchema = zodToCamelCase(schema, {bidirectional: true});
       const results = camelCaseSchema.safeParse({
         // @ts-expect-error
         keyTwo: "one",
@@ -191,7 +192,7 @@ describe("zodToCamelCaseInputOutput", () => {
           foo_bar: z.number(),
         }),
       });
-      const camelCaseSchema = zodToCamelCaseInputAndOutput(schema);
+      const camelCaseSchema = zodToCamelCase(schema, {bidirectional: true});
       const results = camelCaseSchema.parse({
         keyOne: "one",
         keyTwo: "two",
@@ -212,7 +213,7 @@ describe("zodToCamelCaseInputOutput", () => {
       const schema = z.object({
         key_one: z.string(),
       });
-      const camelCaseSchema = zodToCamelCaseInputAndOutput(schema);
+      const camelCaseSchema = zodToCamelCase(schema, {bidirectional: true});
       expect(() => {
         camelCaseSchema.parse({
           // @ts-expect-error
@@ -243,7 +244,7 @@ describe("zodToCamelCaseInputOutput", () => {
           return "";
         }),
       });
-      const camelCaseSchema = zodToCamelCaseInputAndOutput(schema);
+      const camelCaseSchema = zodToCamelCase(schema, {bidirectional: true});
       expect(() => {
         camelCaseSchema.parse({
           keyOne: "one",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -12,7 +12,7 @@ describe("zodToCamelCaseOutput", () => {
         }),
       });
       const camelCaseSchema = zodToCamelCase(schema);
-      type Foo = z.infer<typeof camelCaseSchema>
+      type Foo = z.infer<typeof camelCaseSchema>;
       const results = camelCaseSchema.safeParse({
         key_one: "one",
         key_two: "two",
@@ -138,7 +138,7 @@ describe("zodToCamelCaseInputOutput", () => {
           foo_bar: z.number(),
         }),
       });
-      const camelCaseSchema = zodToCamelCase(schema, {bidirectional: true});
+      const camelCaseSchema = zodToCamelCase(schema, { bidirectional: true });
       const results = camelCaseSchema.safeParse({
         keyOne: "one",
         keyTwo: "two",
@@ -160,7 +160,7 @@ describe("zodToCamelCaseInputOutput", () => {
       const schema = z.object({
         key_one: z.string(),
       });
-      const camelCaseSchema = zodToCamelCase(schema, {bidirectional: true});
+      const camelCaseSchema = zodToCamelCase(schema, { bidirectional: true });
       const results = camelCaseSchema.safeParse({
         // @ts-expect-error
         keyTwo: "one",
@@ -192,7 +192,7 @@ describe("zodToCamelCaseInputOutput", () => {
           foo_bar: z.number(),
         }),
       });
-      const camelCaseSchema = zodToCamelCase(schema, {bidirectional: true});
+      const camelCaseSchema = zodToCamelCase(schema, { bidirectional: true });
       const results = camelCaseSchema.parse({
         keyOne: "one",
         keyTwo: "two",
@@ -213,7 +213,7 @@ describe("zodToCamelCaseInputOutput", () => {
       const schema = z.object({
         key_one: z.string(),
       });
-      const camelCaseSchema = zodToCamelCase(schema, {bidirectional: true});
+      const camelCaseSchema = zodToCamelCase(schema, { bidirectional: true });
       expect(() => {
         camelCaseSchema.parse({
           // @ts-expect-error
@@ -244,7 +244,7 @@ describe("zodToCamelCaseInputOutput", () => {
           return "";
         }),
       });
-      const camelCaseSchema = zodToCamelCase(schema, {bidirectional: true});
+      const camelCaseSchema = zodToCamelCase(schema, { bidirectional: true });
       expect(() => {
         camelCaseSchema.parse({
           keyOne: "one",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -12,7 +12,6 @@ describe("zodToCamelCaseOutput", () => {
         }),
       });
       const camelCaseSchema = zodToCamelCase(schema);
-      type Foo = z.infer<typeof camelCaseSchema>;
       const results = camelCaseSchema.safeParse({
         key_one: "one",
         key_two: "two",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,17 +5,19 @@ import { rewriteErrorPathsToCamel } from "./error";
 
 export { keysToCamelCase, keysToSnakeCase };
 
-type zodToCamelCaseOptionsTrue = {bidirectional: true};
-type zodToCamelCaseOptionsFalse = {bidirectional?: false};
-export type zodToCamelCaseOptions = {bidirectional?: boolean};
+type zodToCamelCaseOptionsTrue = { bidirectional: true };
+type zodToCamelCaseOptionsFalse = { bidirectional?: false };
+export type zodToCamelCaseOptions = { bidirectional?: boolean };
 
 export function zodToCamelCase<T extends ZodType>(
   schema: T,
   // Overload for 'true' condition
-  options: zodToCamelCaseOptionsTrue
-): Omit<ZodType<ZodContribKeysToCamel<z.infer<T>>>, 'parse' | 'safeParse'> & {
+  options: zodToCamelCaseOptionsTrue,
+): Omit<ZodType<ZodContribKeysToCamel<z.infer<T>>>, "parse" | "safeParse"> & {
   // Expecting camel-case input to parse
-  parse(input: ZodContribKeysToCamel<z.infer<T>>): ZodContribKeysToCamel<z.infer<T>>;
+  parse(
+    input: ZodContribKeysToCamel<z.infer<T>>,
+  ): ZodContribKeysToCamel<z.infer<T>>;
   // Expecting camel-case input to safeParse
   safeParse(input: ZodContribKeysToCamel<z.infer<T>>): {
     success: boolean;
@@ -27,8 +29,8 @@ export function zodToCamelCase<T extends ZodType>(
 export function zodToCamelCase<T extends ZodType>(
   schema: T,
   // Overload for 'false' and 'missing' condition
-  options?: zodToCamelCaseOptionsFalse
-): Omit<ZodType<ZodContribKeysToCamel<z.infer<T>>>, 'parse' | 'safeParse'> & {
+  options?: zodToCamelCaseOptionsFalse,
+): Omit<ZodType<ZodContribKeysToCamel<z.infer<T>>>, "parse" | "safeParse"> & {
   // Expecting snake-case-case input to parse
   parse(input: z.infer<T>): ZodContribKeysToCamel<z.infer<T>>;
   // Expecting snake-case-case input to safeParse
@@ -39,17 +41,21 @@ export function zodToCamelCase<T extends ZodType>(
   };
 };
 
-
-export function zodToCamelCase<T extends ZodType>(schema: T, options: zodToCamelCaseOptions={}) {
+export function zodToCamelCase<T extends ZodType>(
+  schema: T,
+  options: zodToCamelCaseOptions = {},
+) {
   const { bidirectional } = options;
   const newSchema = z
     .preprocess((input) => {
       if (bidirectional) {
-        return keysToSnakeCase(input as any)
+        return keysToSnakeCase(input as any);
       }
-      return input
+      return input;
     }, schema)
-    .transform((data) => keysToCamelCase(data) as ZodContribKeysToCamel<z.infer<T>>);
+    .transform(
+      (data) => keysToCamelCase(data) as ZodContribKeysToCamel<z.infer<T>>,
+    );
 
   return {
     ...newSchema,
@@ -71,7 +77,9 @@ export function zodToCamelCase<T extends ZodType>(schema: T, options: zodToCamel
       if (!result.success) {
         return {
           success: false as const,
-          error: bidirectional ? rewriteErrorPathsToCamel(result.error) : result.error,
+          error: bidirectional
+            ? rewriteErrorPathsToCamel(result.error)
+            : result.error,
         };
       }
       return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,47 +5,64 @@ import { rewriteErrorPathsToCamel } from "./error";
 
 export { keysToCamelCase, keysToSnakeCase };
 
-// Fully generic reusable function with internal type mapping
-export function zodToCamelCaseOutput<T extends ZodType>(schema: T) {
-  const newSchema = schema.transform((data) => keysToCamelCase(data));
-  return {
-    ...newSchema,
-    parse(input: z.infer<T>): ZodContribKeysToCamel<z.infer<T>> {
-      try {
-        const parsed = newSchema.parse(input);
-        return keysToCamelCase(parsed) as ZodContribKeysToCamel<z.infer<T>>;
-      } catch (err) {
-        throw err;
-      }
-    },
-    safeParse(input: z.infer<T>) {
-      const result = newSchema.safeParse(input);
-      if (!result.success) {
-        return { success: false as const, error: result.error };
-      }
-      return {
-        success: true as const,
-        data: keysToCamelCase(result.data) as ZodContribKeysToCamel<z.infer<T>>,
-      };
-    },
-  };
-}
+type zodToCamelCaseOptionsTrue = {bidirectional: true};
+type zodToCamelCaseOptionsFalse = {bidirectional?: false};
+export type zodToCamelCaseOptions = {bidirectional?: boolean};
 
-// Fully generic reusable function with internal type mapping
-export function zodToCamelCaseInputAndOutput<T extends ZodType>(schema: T) {
+export function zodToCamelCase<T extends ZodType>(
+  schema: T,
+  // Overload for 'true' condition
+  options: zodToCamelCaseOptionsTrue
+): Omit<ZodType<ZodContribKeysToCamel<z.infer<T>>>, 'parse' | 'safeParse'> & {
+  // Expecting camel-case input to parse
+  parse(input: ZodContribKeysToCamel<z.infer<T>>): ZodContribKeysToCamel<z.infer<T>>;
+  // Expecting camel-case input to safeParse
+  safeParse(input: ZodContribKeysToCamel<z.infer<T>>): {
+    success: boolean;
+    data?: ZodContribKeysToCamel<z.infer<T>>;
+    error?: any;
+  };
+};
+
+export function zodToCamelCase<T extends ZodType>(
+  schema: T,
+  // Overload for 'false' and 'missing' condition
+  options?: zodToCamelCaseOptionsFalse
+): Omit<ZodType<ZodContribKeysToCamel<z.infer<T>>>, 'parse' | 'safeParse'> & {
+  // Expecting snake-case-case input to parse
+  parse(input: z.infer<T>): ZodContribKeysToCamel<z.infer<T>>;
+  // Expecting snake-case-case input to safeParse
+  safeParse(input: z.infer<T>): {
+    success: boolean;
+    data?: ZodContribKeysToCamel<z.infer<T>>;
+    error?: any;
+  };
+};
+
+
+export function zodToCamelCase<T extends ZodType>(schema: T, options: zodToCamelCaseOptions={}) {
+  const { bidirectional } = options;
   const newSchema = z
-    .preprocess((input) => keysToSnakeCase(input as any), schema)
-    .transform((data) => keysToCamelCase(data));
+    .preprocess((input) => {
+      if (bidirectional) {
+        return keysToSnakeCase(input as any)
+      }
+      return input
+    }, schema)
+    .transform((data) => keysToCamelCase(data) as ZodContribKeysToCamel<z.infer<T>>);
+
   return {
     ...newSchema,
-    parse(
-      input: ZodContribKeysToCamel<z.infer<T>>,
-    ): ZodContribKeysToCamel<z.infer<T>> {
+    parse: (
+      input: ZodContribKeysToCamel<z.infer<T>> | z.infer<T>,
+    ): ZodContribKeysToCamel<z.infer<T>> => {
       try {
         const parsed = newSchema.parse(input);
         return keysToCamelCase(parsed) as ZodContribKeysToCamel<z.infer<T>>;
       } catch (err) {
-        if (err instanceof ZodError) throw rewriteErrorPathsToCamel(err);
+        if (bidirectional && err instanceof ZodError) {
+          throw rewriteErrorPathsToCamel(err);
+        }
         throw err;
       }
     },
@@ -54,7 +71,7 @@ export function zodToCamelCaseInputAndOutput<T extends ZodType>(schema: T) {
       if (!result.success) {
         return {
           success: false as const,
-          error: rewriteErrorPathsToCamel(result.error),
+          error: bidirectional ? rewriteErrorPathsToCamel(result.error) : result.error,
         };
       }
       return {


### PR DESCRIPTION
This updates the API from 

 - `zodToCamelCaseInput(schema)` -> `zodToCamelCase(schema)`
 - `zodToCamelCaseInputAndOutput(schema)` -> `zodToCamelCase(schema, {bidirectional: true})`

It also fixes bug where `z.infer<T>` would be `unknown`

Fixes #2