### PR TITLE
Fully test types in the test runner and fixes for type edge case

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "types": "./dist/npm/types.d.ts",
   "type": "module",
   "scripts": {
+    "check-types": "tsc --noEmit",
     "lint": "npx prettier . --check",
     "test": "vitest run --coverage",
     "test:watch": "vitest run --watch",

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -1,0 +1,59 @@
+import { describe, expectTypeOf, test } from "vitest";
+import { ZodContribKeysToCamel, ZodContribSnakeToCamel } from "./types";
+
+describe("types", () => {
+  test("ZodContribSnakeToCamel", () => {
+    expectTypeOf<
+      ZodContribSnakeToCamel<"foo_bar_baz">
+    >().toEqualTypeOf<"fooBarBaz">();
+    expectTypeOf<
+      ZodContribSnakeToCamel<"foo_bar__baz">
+    >().toEqualTypeOf<"fooBarBaz">();
+    expectTypeOf<
+      ZodContribSnakeToCamel<"foo__bar_baz">
+    >().toEqualTypeOf<"fooBarBaz">();
+    expectTypeOf<ZodContribSnakeToCamel<"foo__">>().toEqualTypeOf<"foo">();
+    expectTypeOf<ZodContribSnakeToCamel<"foo_">>().toEqualTypeOf<"foo">();
+    expectTypeOf<ZodContribSnakeToCamel<"__foo_">>().toEqualTypeOf<"foo">();
+  });
+
+  describe("ZodContribKeysToCamel", () => {
+    test("simple object", () => {
+      expectTypeOf<
+        ZodContribKeysToCamel<{
+          foo_bar_baz: {
+            __foo_bar_baz_?: {
+              name: string;
+            };
+          };
+        }>
+      >().toEqualTypeOf<{
+        fooBarBaz: {
+          fooBarBaz?: {
+            name: string;
+          };
+        };
+      }>();
+    });
+
+    test("with arrays", () => {
+      expectTypeOf<
+        ZodContribKeysToCamel<{
+          foo_bar_baz: {
+            __foo_bar_baz_: {
+              name: string;
+              check: boolean;
+            }[];
+          } | null;
+        }>
+      >().toEqualTypeOf<{
+        fooBarBaz: {
+          fooBarBaz: {
+            name: string;
+            check: boolean;
+          }[];
+        } | null;
+      }>();
+    });
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,17 @@
-// Type-level mapping: snake_case → camelCase
-export type ZodContribSnakeToCamel<S extends string> =
+// step 1: remove leading underscores
+export type ZodContribSnakeToCamelStep1<S extends string> =
+  S extends `_${infer Tail}`
+    ? ZodContribSnakeToCamelStep1<Tail>
+    : ZodContribSnakeToCamelStep2<S>;
+
+// step 1: snake_case -> camelCase
+type ZodContribSnakeToCamelStep2<S extends string> =
   S extends `${infer Head}_${infer Tail}`
-    ? `${Head}${Capitalize<ZodContribSnakeToCamel<Tail>>}`
+    ? `${Head}${Capitalize<ZodContribSnakeToCamelStep2<Tail>>}`
     : S;
+
+export type ZodContribSnakeToCamel<S extends string> =
+  ZodContribSnakeToCamelStep1<S>;
 
 export type ZodContribKeysToCamel<U> =
   U extends Array<infer V>


### PR DESCRIPTION
Fully test types in the test runner using `expectTypeOf(...)` and fixes for type edge case.

**Edge case fixed**: Previously `ZodContribSnakeToCamel<"_foo">` would resolve to `"Foo"` rather than `"foo"` 