### PR TITLE
Don't allow keys to clash

### DIFF
--- a/src/format.test.ts
+++ b/src/format.test.ts
@@ -4,6 +4,7 @@ import {
   camelToSnakeCase,
   keysToCamelCase,
   keysToSnakeCase,
+  prettyFormatArray,
   snakeToCamelCase,
 } from "./format";
 
@@ -15,6 +16,11 @@ describe("snakeToCamelCase", () => {
     { input: "foo__", expected: "foo" },
     { input: "foo_", expected: "foo" },
     { input: "__foo_", expected: "foo" },
+    { input: "__foo_", expected: "foo" },
+    { input: "__ID_", expected: "id" },
+    { input: "fooBarBaz", expected: "foobarbaz" },
+    { input: "c_$fé", expected: "c$fé" },
+    { input: "some_c$fé", expected: "someC$fé" },
   ];
 
   for (const { input, expected } of TEST_CASES) {
@@ -100,5 +106,21 @@ describe("keysToSnakeCase", () => {
         expect(keysToSnakeCase(input)).toEqual(expected);
       },
     );
+  }
+});
+
+describe("prettyFormatArray", () => {
+  const TEST_CASES = [
+    {input: ["foo"], expected: `"foo"`},
+    {input: ["foo", "bar"], expected: `"foo" & "bar"`},
+    {input: ["foo", "bar", "baz"], expected: `"foo", "bar" & "baz"`},
+    {input: ["foo", 1, "baz"], expected: `"foo", 1 & "baz"`},
+    {input: ["foo", false, "baz"], expected: `"foo", false & "baz"`},
+  ];
+
+  for (const { input, expected } of TEST_CASES) {
+    test(`${JSON.stringify(input)} -> ${JSON.stringify(expected)}`, () => {
+      expect(prettyFormatArray(input)).toEqual(expected);
+    });
   }
 });

--- a/src/format.ts
+++ b/src/format.ts
@@ -14,10 +14,33 @@ export function keysToSnakeCase<T>(obj: T): any {
   return obj;
 }
 
+
+export function reverseMappings<T>(obj: T, mappings: Map<string, string>, path: string[]=[]): any {
+  if (Array.isArray(obj)) {
+    return obj.map(s => {
+      reverseMappings(s, mappings, path.concat("*"))
+    });
+  }
+  if (obj !== null && typeof obj === "object") {
+    return Object.fromEntries(
+      Object.entries(obj).map(([k, v]) => {
+        const ip = [...path, k];
+        const rm = mappings.get(ip.join("."));
+        return [
+          rm,
+          reverseMappings(v, mappings, [...path, k]),
+        ]
+      }),
+    );
+  }
+  return mappings.get(path.join("."))!;
+}
+
 export const snakeToCamelCase = (str: string) => {
   return str
+    .toLocaleLowerCase()
     .replace(/^_+/, "")
-    .replace(/_+([a-z])/g, (_, c) => c.toUpperCase())
+    .replace(/_+(\S)/g, (_, c) => c.toUpperCase())
     .replace(/_+$/, "");
 };
 
@@ -32,4 +55,12 @@ export function keysToCamelCase<T>(obj: T): any {
     );
   }
   return obj;
+}
+
+export function prettyFormatArray (arr: (string | number | boolean)[]) {
+  const items = arr.map(s => JSON.stringify(s));
+  if (items.length < 2) return items[0];
+  const end = items.slice(-1);
+  const start = items.slice(0, -1);
+  return [start.join(", "), "&", ...end].join(" ")
 }

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -15,6 +15,11 @@ describe("types", () => {
     expectTypeOf<ZodContribSnakeToCamel<"foo__">>().toEqualTypeOf<"foo">();
     expectTypeOf<ZodContribSnakeToCamel<"foo_">>().toEqualTypeOf<"foo">();
     expectTypeOf<ZodContribSnakeToCamel<"__foo_">>().toEqualTypeOf<"foo">();
+    expectTypeOf<ZodContribSnakeToCamel<"__ID_">>().toEqualTypeOf<"id">();
+    expectTypeOf<ZodContribSnakeToCamel<"fooBarBaz">>().toEqualTypeOf<"foobarbaz">();
+    expectTypeOf<ZodContribSnakeToCamel<"c$fé">>().toEqualTypeOf<"c$fé">();
+    expectTypeOf<ZodContribSnakeToCamel<"c_$fé">>().toEqualTypeOf<"c$fé">();
+    expectTypeOf<ZodContribSnakeToCamel<"some_c$fé">>().toEqualTypeOf<"someC$fé">();
   });
 
   describe("ZodContribKeysToCamel", () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,7 @@ type ZodContribSnakeToCamelStep2<S extends string> =
     : S;
 
 export type ZodContribSnakeToCamel<S extends string> =
-  ZodContribSnakeToCamelStep1<S>;
+  ZodContribSnakeToCamelStep1<Lowercase<S>>;
 
 export type ZodContribKeysToCamel<U> =
   U extends Array<infer V>

--- a/src/zod.test.ts
+++ b/src/zod.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "vitest";
+import { zodKeys } from "./zod";
+import z from "zod";
+
+describe("zodKeys", () => {
+    test("simple", () => {
+        const keys = zodKeys(z.object({
+            test: z.string(),
+            foo_bar: z.array(
+                z.object({
+                    bar_baz: z.string(),
+                    one_two: z.object({
+                        three_four: z.string()
+                    })
+                })
+            )
+        }))
+        expect(keys).toEqual([
+            ["test"],
+            ["foo_bar", "bar_baz"],
+            ["foo_bar", "one_two", "three_four"],
+        ])
+    })
+})

--- a/src/zod.ts
+++ b/src/zod.ts
@@ -1,0 +1,67 @@
+import z from "zod";
+import { $ZodType } from "zod/v4/core";
+
+// From <https://github.com/colinhacks/zod/discussions/2134#discussioncomment-5194111>
+export function zodKeys <T extends $ZodType>(schema: T): string[][] {
+    // make sure schema is not null or undefined
+    if (schema === null || schema === undefined) return [];
+    // check if schema is nullable or optional
+    if (schema instanceof z.ZodNullable || schema instanceof z.ZodOptional) return zodKeys(schema.unwrap());
+    // check if schema is an array
+    if (schema instanceof z.ZodArray) return zodKeys(schema.element);
+    // check if schema is an object
+    if (schema instanceof z.ZodObject) {
+        // get key/value pairs from schema
+        const entries = Object.entries(schema.shape);
+        // loop through key/value pairs
+
+        const out: string[][] = [];
+        for (const [key,value] of entries) {
+        if (value instanceof z.ZodType) {
+            const subKeyList = zodKeys(value);
+            if (subKeyList.length > 0) {
+            for (const subKeys of subKeyList) {
+                out.push([key].concat(subKeys ?? []))
+            }
+            } else {
+            out.push([key])
+            }
+        } else {
+            out.push([key]);
+        }
+        }
+        return out;
+    }
+    // return empty array
+    return [];
+};
+
+export function zodSiblingKeys <T extends $ZodType>(schema: T, fn: (keys: string[], path: string[], type: "union" | "object") => void, path: string[]=[]): void {
+    // make sure schema is not null or undefined
+    if (schema === null || schema === undefined) [];
+
+    if (schema instanceof z.ZodUnion) {
+        for (const opt of schema.options) {
+            zodSiblingKeys(opt, fn, path)
+        }
+    }
+    // check if schema is nullable or optional
+    if (schema instanceof z.ZodNullable || schema instanceof z.ZodOptional) zodSiblingKeys(schema.unwrap(), fn, path);
+    // check if schema is an array
+    if (schema instanceof z.ZodArray) zodSiblingKeys(schema.element, fn, path.concat("*"));
+    // check if schema is an object
+    if (schema instanceof z.ZodObject) {
+        // get key/value pairs from schema
+        const entries = Object.entries(schema.shape);
+        // loop through key/value pairs
+
+        fn(Object.keys(schema.shape), path, "object")
+
+        const out: string[][] = [];
+        for (const [key,value] of entries) {
+            if (value instanceof z.ZodType) {
+                zodSiblingKeys(value, fn, path.concat(key));
+            }
+        }
+    }
+};


### PR DESCRIPTION
Don't allow keys to clash, for example `_foo` and `foo_` would both result in `foo` when converting the output.

If we have clashing keys, it now throws an error

Works towards #10 