### PR TITLE
Better conversion from snakecase ↔️ camelcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ Convert zod schema object keys to camel case.
 
 The `zodToCamelCase` supports both unidirectional and bidirectional transformation of zod schemas
 
+### Allowed object keys
+
+Object keys will type-error/runtime-error if they don't match this pattern
+
+```
+/_*[a-z_]_*/
+```
+
 ### `zodToCamelCase` (unidirectional)
 
 By default `zodToCamelCase` supports unidirectional transformation of the schema.

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "node": ">=20.x"
       },
       "peerDependencies": {
-        "zod": "^4.1.11"
+        "zod": "^4.3.6"
       }
     },
     "node_modules/@actions/core": {
@@ -3727,9 +3727,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
-      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
       "peer": true,
       "funding": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     "node": ">=20.x"
   },
   "peerDependencies": {
-    "zod": "^4.1.11"
+    "zod": "^4.3.6"
   }
 }

--- a/src/format.test.ts
+++ b/src/format.test.ts
@@ -6,18 +6,10 @@ import {
   keysToSnakeCase,
   snakeToCamelCase,
 } from "./format";
+import { snakeToCamelTestData } from "./helpers/data";
 
 describe("snakeToCamelCase", () => {
-  const TEST_CASES = [
-    { input: "foo_bar_baz", expected: "fooBarBaz" },
-    { input: "foo_bar__baz", expected: "fooBarBaz" },
-    { input: "foo__bar_baz", expected: "fooBarBaz" },
-    { input: "foo__", expected: "foo" },
-    { input: "foo_", expected: "foo" },
-    { input: "__foo_", expected: "foo" },
-  ];
-
-  for (const { input, expected } of TEST_CASES) {
+  for (const { input, expected } of snakeToCamelTestData) {
     test(`${JSON.stringify(input)} -> ${JSON.stringify(expected)}`, () => {
       expect(snakeToCamelCase(input)).toEqual(expected);
     });
@@ -25,14 +17,9 @@ describe("snakeToCamelCase", () => {
 });
 
 describe("camelToSnakeCase", () => {
-  const TEST_CASES = [
-    { input: "fooBarBaz", expected: "foo_bar_baz" },
-    { input: "foo", expected: "foo" },
-  ];
-
-  for (const { input, expected } of TEST_CASES) {
-    test(`${JSON.stringify(input)} -> ${JSON.stringify(expected)}`, () => {
-      expect(camelToSnakeCase(input)).toEqual(expected);
+  for (const { input, expected } of snakeToCamelTestData) {
+    test(`${JSON.stringify(expected)} -> ${JSON.stringify(input)}`, () => {
+      expect(camelToSnakeCase(expected)).toEqual(input);
     });
   }
 });
@@ -53,7 +40,7 @@ describe("keysToCamelCase", () => {
         fooBar: "testing",
         additionalProps: {
           testBaz: {
-            foo: [{ fooBar: "foo" }],
+            foo: [{ __fooBar: "foo" }],
           },
         },
       },

--- a/src/format.test.ts
+++ b/src/format.test.ts
@@ -9,18 +9,26 @@ import {
 import { snakeToCamelTestData } from "./helpers/data";
 
 describe("snakeToCamelCase", () => {
-  for (const { input, expected } of snakeToCamelTestData) {
-    test(`${JSON.stringify(input)} -> ${JSON.stringify(expected)}`, () => {
-      expect(snakeToCamelCase(input)).toEqual(expected);
-    });
+  for (const item of snakeToCamelTestData) {
+    if (item.throwsError) {
+      test(`${JSON.stringify(item.input)} -> (throws)`, () => {
+        expect(() => snakeToCamelCase(item.input)).toThrowError();
+      });
+    } else {
+      test(`${JSON.stringify(item.input)} -> ${JSON.stringify(item.expected)}`, () => {
+        expect(snakeToCamelCase(item.input)).toEqual(item.expected);
+      });
+    }
   }
 });
 
 describe("camelToSnakeCase", () => {
-  for (const { input, expected } of snakeToCamelTestData) {
-    test(`${JSON.stringify(expected)} -> ${JSON.stringify(input)}`, () => {
-      expect(camelToSnakeCase(expected)).toEqual(input);
-    });
+  for (const item of snakeToCamelTestData) {
+    if (!item.throwsError) {
+      test(`${JSON.stringify(item.expected)} -> ${JSON.stringify(item.input)}`, () => {
+        expect(camelToSnakeCase(item.expected)).toEqual(item.input);
+      });
+    }
   }
 });
 

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,5 +1,9 @@
-export const camelToSnakeCase = (str: string) =>
-  str.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
+export const camelToSnakeCase = (str: string) => {
+  return str
+    .replace(/^(_*)(.*)(_*)$/, (_, s: string, m: string, e: string) => {
+      return s+m.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`)+e;
+    })
+}
 
 export function keysToSnakeCase<T>(obj: T): any {
   if (Array.isArray(obj)) return obj.map(keysToSnakeCase);
@@ -16,9 +20,10 @@ export function keysToSnakeCase<T>(obj: T): any {
 
 export const snakeToCamelCase = (str: string) => {
   return str
-    .replace(/^_+/, "")
-    .replace(/_+([a-z])/g, (_, c) => c.toUpperCase())
-    .replace(/_+$/, "");
+    .toLowerCase()
+    .replace(/^(_*)(.*)(_*)$/, (_, s: string, m: string, e: string) => {
+      return s+m.replace(/_+([a-z])/g, (_, c: string) => c.toUpperCase())+e;
+    })
 };
 
 export function keysToCamelCase<T>(obj: T): any {

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,9 +1,14 @@
 export const camelToSnakeCase = (str: string) => {
-  return str
-    .replace(/^(_*)(.*)(_*)$/, (_, s: string, m: string, e: string) => {
-      return s+m.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`)+e;
-    })
-}
+  const out = str.replace(
+    /^(_*)(.*)(_*)$/,
+    (_, s: string, m: string, e: string) => {
+      return (
+        s + m.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`) + e
+      );
+    },
+  );
+  return out;
+};
 
 export function keysToSnakeCase<T>(obj: T): any {
   if (Array.isArray(obj)) return obj.map(keysToSnakeCase);
@@ -19,21 +24,26 @@ export function keysToSnakeCase<T>(obj: T): any {
 }
 
 export const snakeToCamelCase = (str: string) => {
+  if (!str.match(/^_*([a-z]|[a-z][_])+_*$/)) {
+    throw new Error("Invalid");
+  }
   return str
     .toLowerCase()
     .replace(/^(_*)(.*)(_*)$/, (_, s: string, m: string, e: string) => {
-      return s+m.replace(/_+([a-z])/g, (_, c: string) => c.toUpperCase())+e;
-    })
+      return s + m.replace(/_+([a-z])/g, (_, c: string) => c.toUpperCase()) + e;
+    });
 };
 
 export function keysToCamelCase<T>(obj: T): any {
-  if (Array.isArray(obj)) return obj.map(keysToCamelCase);
+  if (Array.isArray(obj))
+    return obj.map((o) => {
+      return keysToCamelCase(o);
+    });
   if (obj !== null && typeof obj === "object") {
     return Object.fromEntries(
-      Object.entries(obj).map(([k, v]) => [
-        snakeToCamelCase(k),
-        keysToCamelCase(v),
-      ]),
+      Object.entries(obj).map(([k, v]) => {
+        return [snakeToCamelCase(k), keysToCamelCase(v)];
+      }),
     );
   }
   return obj;

--- a/src/helpers/data.ts
+++ b/src/helpers/data.ts
@@ -1,0 +1,14 @@
+export const snakeToCamelTestData = [
+    { input: "foo_bar", expected: "fooBar" },
+    { input: "foo_bar_baz", expected: "fooBarBaz" },
+    // { input: "foo_bar__baz", expected: "fooBarBaz" },
+    // { input: "foo__bar_baz", expected: "fooBarBaz" },
+    // { input: "foo__", expected: "foo__" },
+    { input: "foo_", expected: "foo_" },
+    { input: "__foo_", expected: "__foo_" },
+    // { input: "__ID_", expected: "__id_" },
+    // { input: "foo__bar", expected: "fooBar" },
+    // { input: "fooBarBaz", expected: "foobarbaz" },
+    // { input: "c_$fé", expected: "c$fé" },
+    { input: "some_c$fé", expected: "someC$fé" },
+] as const

--- a/src/helpers/data.ts
+++ b/src/helpers/data.ts
@@ -1,14 +1,28 @@
-export const snakeToCamelTestData = [
-    { input: "foo_bar", expected: "fooBar" },
-    { input: "foo_bar_baz", expected: "fooBarBaz" },
-    // { input: "foo_bar__baz", expected: "fooBarBaz" },
-    // { input: "foo__bar_baz", expected: "fooBarBaz" },
-    // { input: "foo__", expected: "foo__" },
-    { input: "foo_", expected: "foo_" },
-    { input: "__foo_", expected: "__foo_" },
-    // { input: "__ID_", expected: "__id_" },
-    // { input: "foo__bar", expected: "fooBar" },
-    // { input: "fooBarBaz", expected: "foobarbaz" },
-    // { input: "c_$fé", expected: "c$fé" },
-    { input: "some_c$fé", expected: "someC$fé" },
-] as const
+type TestType =
+  | {
+      input: string;
+      expected: string;
+      throwsError?: undefined;
+    }
+  | {
+      input: string;
+      throwsError: true;
+    };
+
+export const snakeToCamelTestData: TestType[] = [
+  { input: "foo_bar", expected: "fooBar" },
+  { input: "foo_bar_baz", expected: "fooBarBaz" },
+  { input: "foo__", expected: "foo__" },
+  { input: "foo_", expected: "foo_" },
+  { input: "__foo_", expected: "__foo_" },
+  { input: "_", throwsError: true },
+  { input: "__", throwsError: true },
+  { input: "foo_bar__baz", throwsError: true },
+  { input: "foo__bar_baz", throwsError: true },
+  { input: "__ID_", throwsError: true },
+  { input: "foo__bar", throwsError: true },
+  { input: "fooBarBaz", throwsError: true },
+  { input: "ca_fé", throwsError: true },
+  { input: "c_$fé", throwsError: true },
+  { input: "some_c$fé", throwsError: true },
+] as const;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -624,7 +624,7 @@ describe("zodToCamelCase (bidirectional)", () => {
       expect(result).toEqual("testing");
     });
 
-    test("array schema", () => {
+    test.only("array schema", () => {
       const schema = z.array(z.object({ foo_bar: z.string() }));
       const camelCaseSchema = zodToCamelCase(schema, { bidirectional: true });
       const result = camelCaseSchema.parse([{ fooBar: "testing" }]);

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,24 +48,15 @@ export default function zodToCamelCase<T extends ZodType>(
   options: zodToCamelCaseOptions = {},
 ) {
   const { bidirectional = false } = options;
-  const newSchema = z
-    .preprocess((input) => {
-      if (bidirectional) {
-        return keysToSnakeCase(input as any);
-      }
-      return input;
-    }, schema)
-    .transform(
-      (data) => keysToCamelCase(data) as ZodContribKeysToCamel<z.infer<T>>,
-    );
 
   return {
-    ...newSchema,
+    ...schema,
     parse: (
       input: ZodContribKeysToCamel<z.infer<T>> | z.infer<T>,
     ): ZodContribKeysToCamel<z.infer<T>> => {
       try {
-        const parsed = newSchema.parse(input);
+        const parsedInput = bidirectional ? keysToSnakeCase(input) : input
+        const parsed = schema.parse(parsedInput);
         return keysToCamelCase(parsed) as ZodContribKeysToCamel<z.infer<T>>;
       } catch (err) {
         if (bidirectional && err instanceof ZodError) {
@@ -75,7 +66,8 @@ export default function zodToCamelCase<T extends ZodType>(
       }
     },
     safeParse(input: ZodContribKeysToCamel<z.infer<T>>) {
-      const result = newSchema.safeParse(input);
+      const parsedInput = bidirectional ? keysToSnakeCase(input) : input
+      const result = schema.safeParse(parsedInput);
       if (!result.success) {
         return {
           success: false as const,

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,9 +55,12 @@ export default function zodToCamelCase<T extends ZodType>(
       input: ZodContribKeysToCamel<z.infer<T>> | z.infer<T>,
     ): ZodContribKeysToCamel<z.infer<T>> => {
       try {
-        const parsedInput = bidirectional ? keysToSnakeCase(input) : input
+        const parsedInput = bidirectional ? keysToSnakeCase(input) : input;
         const parsed = schema.parse(parsedInput);
-        return keysToCamelCase(parsed) as ZodContribKeysToCamel<z.infer<T>>;
+        const result = keysToCamelCase(parsed) as ZodContribKeysToCamel<
+          z.infer<T>
+        >;
+        return result;
       } catch (err) {
         if (bidirectional && err instanceof ZodError) {
           throw rewriteErrorPathsToCamel(err);
@@ -66,7 +69,7 @@ export default function zodToCamelCase<T extends ZodType>(
       }
     },
     safeParse(input: ZodContribKeysToCamel<z.infer<T>>) {
-      const parsedInput = bidirectional ? keysToSnakeCase(input) : input
+      const parsedInput = bidirectional ? keysToSnakeCase(input) : input;
       const result = schema.safeParse(parsedInput);
       if (!result.success) {
         return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { z, ZodError, ZodType } from "zod";
+import { z, ZodArray, ZodError, ZodObject, ZodRawShape, ZodType } from "zod";
 import { keysToCamelCase, keysToSnakeCase } from "./format";
 import { ZodContribSnakeToCamel, ZodContribKeysToCamel } from "./types";
 import { rewriteErrorPathsToCamel } from "./error";
@@ -11,6 +11,9 @@ export type zodToCamelCaseOptions = { bidirectional?: boolean };
 // parse(...) with optional `Input` type
 type parse<Input, T> = (input: Input) => ZodContribKeysToCamel<z.infer<T>>;
 
+type ShapeOfObject<T> = T extends ZodObject<infer Shape, any> ? Shape : never;
+type ShapeOfArray<T> = T extends ZodArray<infer Shape> ? Shape : never;
+
 // safeParse(...) with optional `Input` type
 type safeParse<Input, T> = (input: Input) => {
   success: boolean;
@@ -18,16 +21,98 @@ type safeParse<Input, T> = (input: Input) => {
   error?: any;
 };
 
+type SnakeToCamel<S extends string> =
+  S extends `${infer H}_${infer T}`
+    ? `${H}${Capitalize<SnakeToCamel<T>>}`
+    : S;
+
+export type RewriteShapeKeys<S extends ZodRawShape> = {
+  [K in keyof S as SnakeToCamel<K & string>]:
+    S[K] extends ZodObject<infer Inner, any>
+      ? ZodObject<RewriteShapeKeys<Inner>>
+    : S[K] extends ZodArray<infer E>
+      ? ZodArray<
+          E extends ZodObject<infer Inner2, any>
+            ? ZodObject<RewriteShapeKeys<Inner2>>
+            : E
+        >
+    : S[K];
+};
+
+/**
+ * General top-level rewrite — supports objects, arrays, or primitives.
+ */
+export type RewriteZodSchemaKeys<T> =
+  T extends ZodObject<infer Shape, any>
+    ? ZodObject<RewriteShapeKeys<Shape>>
+    : T extends ZodArray<infer Elem>
+      ? ZodArray<
+          Elem extends ZodObject<infer Inner, any>
+            ? ZodObject<RewriteShapeKeys<Inner>>
+            : Elem extends ZodArray<any>
+              ? RewriteZodSchemaKeys<Elem>
+              : Elem
+        >
+      : T;
+
 // zodToCamelCase (unidirectional)
-export default function zodToCamelCase<T extends ZodType>(
+export default function zodToCamelCase<T extends ZodObject, Shape=ZodObject<RewriteShapeKeys<ShapeOfObject<T>>>>(
   schema: T,
   // Overload for 'true' condition
   options: { bidirectional: true },
-): Omit<ZodType<ZodContribKeysToCamel<z.infer<T>>>, "parse" | "safeParse"> & {
+): Omit<Shape, "parse" | "safeParse"> & {
   // Expecting snake-case-case input to parse
-  parse: parse<ZodContribKeysToCamel<z.infer<T>>, T>;
+  parse: parse<z.input<Shape>, Shape>;
   // Expecting snake-case-case input to safeParse
-  safeParse: safeParse<ZodContribKeysToCamel<z.infer<T>>, T>;
+  safeParse: safeParse<z.input<Shape>, Shape>;
+};
+
+// zodToCamelCase (bidirectional)
+export default function zodToCamelCase<T extends ZodObject, Shape=ZodObject<RewriteShapeKeys<ShapeOfObject<T>>>>(
+  schema: T,
+  // Overload for 'false' and 'missing' condition
+  options?: { bidirectional?: false },
+): Omit<Shape, "parse" | "safeParse"> & {
+  // Expecting snake-case-case input to parse
+  parse: parse<z.infer<T>, Shape>;
+  // Expecting snake-case-case input to safeParse
+  safeParse: safeParse<z.infer<T>, Shape>;
+};
+
+// zodToCamelCase (unidirectional)
+export default function zodToCamelCase<T extends ZodArray, Shape=ZodArray<RewriteZodSchemaKeys<ShapeOfArray<T>>>>(
+  schema: T,
+  // Overload for 'true' condition
+  options: { bidirectional: true },
+): Omit<Shape, "parse" | "safeParse"> & {
+  // Expecting snake-case-case input to parse
+  parse: parse<z.input<Shape>, Shape>;
+  // Expecting snake-case-case input to safeParse
+  safeParse: safeParse<z.input<Shape>, Shape>;
+};
+
+// zodToCamelCase (bidirectional)
+export default function zodToCamelCase<T extends ZodArray, Shape=ZodArray<RewriteZodSchemaKeys<ShapeOfArray<T>>>>(
+  schema: T,
+  // Overload for 'false' and 'missing' condition
+  options?: { bidirectional?: false },
+): Omit<Shape, "parse" | "safeParse"> & {
+  // Expecting snake-case-case input to parse
+  parse: parse<z.infer<T>, Shape>;
+  // Expecting snake-case-case input to safeParse
+  safeParse: safeParse<z.infer<T>, Shape>;
+};
+
+// zodToCamelCase (bidirectional)
+export default function zodToCamelCase<T extends ZodType>(
+  schema: T,
+  // Overload for 'false' and 'missing' condition
+  options?: { bidirectional: true },
+): Omit<T, "parse" | "safeParse"> & {
+  // Expecting snake-case-case input to parse
+  parse: parse<z.infer<T>, T>;
+  // Expecting snake-case-case input to safeParse
+  safeParse: safeParse<z.infer<T>, T>;
 };
 
 // zodToCamelCase (bidirectional)
@@ -35,7 +120,7 @@ export default function zodToCamelCase<T extends ZodType>(
   schema: T,
   // Overload for 'false' and 'missing' condition
   options?: { bidirectional?: false },
-): Omit<ZodType<ZodContribKeysToCamel<z.infer<T>>>, "parse" | "safeParse"> & {
+): Omit<T, "parse" | "safeParse"> & {
   // Expecting snake-case-case input to parse
   parse: parse<z.infer<T>, T>;
   // Expecting snake-case-case input to safeParse

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -1,21 +1,15 @@
 import { describe, expectTypeOf, test } from "vitest";
 import { ZodContribKeysToCamel, ZodContribSnakeToCamel } from "./types";
+import { snakeToCamelTestData } from "./helpers/data";
 
 describe("types", () => {
-  test("ZodContribSnakeToCamel", () => {
-    expectTypeOf<
-      ZodContribSnakeToCamel<"foo_bar_baz">
-    >().toEqualTypeOf<"fooBarBaz">();
-    expectTypeOf<
-      ZodContribSnakeToCamel<"foo_bar__baz">
-    >().toEqualTypeOf<"fooBarBaz">();
-    expectTypeOf<
-      ZodContribSnakeToCamel<"foo__bar_baz">
-    >().toEqualTypeOf<"fooBarBaz">();
-    expectTypeOf<ZodContribSnakeToCamel<"foo__">>().toEqualTypeOf<"foo">();
+  test(`ZodContribSnakeToCamel`, () => {
+    expectTypeOf<ZodContribSnakeToCamel<"foo_bar">>().toEqualTypeOf<"fooBar">();
+    expectTypeOf<ZodContribSnakeToCamel<"foo_bar_baz">>().toEqualTypeOf<"fooBarBaz">();
     expectTypeOf<ZodContribSnakeToCamel<"foo_">>().toEqualTypeOf<"foo">();
-    expectTypeOf<ZodContribSnakeToCamel<"__foo_">>().toEqualTypeOf<"foo">();
-  });
+    expectTypeOf<ZodContribSnakeToCamel<"_foo">>().toEqualTypeOf<"_foo">();
+    expectTypeOf<ZodContribSnakeToCamel<"some_c$fé">>().toEqualTypeOf<"someC$fé">();
+  })
 
   describe("ZodContribKeysToCamel", () => {
     test("simple object", () => {
@@ -29,7 +23,7 @@ describe("types", () => {
         }>
       >().toEqualTypeOf<{
         fooBarBaz: {
-          fooBarBaz?: {
+          __fooBarBaz_?: {
             name: string;
           };
         };
@@ -48,7 +42,7 @@ describe("types", () => {
         }>
       >().toEqualTypeOf<{
         fooBarBaz: {
-          fooBarBaz: {
+          __fooBarBaz_: {
             name: string;
             check: boolean;
           }[];

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -1,15 +1,58 @@
 import { describe, expectTypeOf, test } from "vitest";
-import { ZodContribKeysToCamel, ZodContribSnakeToCamel } from "./types";
-import { snakeToCamelTestData } from "./helpers/data";
+import {
+  DisallowMultipleUnderScores,
+  OnlyAllowedChars,
+  AsCamelCase,
+  ZodContribKeysToCamel,
+  ZodContribSnakeToCamel,
+} from "./types";
 
 describe("types", () => {
+  test("OnlyAllowedChars", () => {
+    expectTypeOf<
+      OnlyAllowedChars<"abcdefghijklmnop">
+    >().toEqualTypeOf<"abcdefghijklmnop">();
+    expectTypeOf<
+      OnlyAllowedChars<"qrstuvwxyz">
+    >().toEqualTypeOf<"qrstuvwxyz">();
+    expectTypeOf<OnlyAllowedChars<"café">>().toBeNever();
+  });
+
+  test("DisallowMultipleUnderScores", () => {
+    expectTypeOf<
+      DisallowMultipleUnderScores<"one_two_three">
+    >().toEqualTypeOf<"one_two_three">();
+    expectTypeOf<DisallowMultipleUnderScores<"one__two_three">>().toBeNever();
+  });
+
+  test("AsCamelCase", () => {
+    expectTypeOf<AsCamelCase<"one_two_three">>().toEqualTypeOf<"oneTwoThree">();
+    // NOTE: This is weak so things like this still pass through, we combine with other type to prevent this
+    expectTypeOf<
+      AsCamelCase<"one__two__three">
+    >().toEqualTypeOf<"oneTwoThree">();
+  });
+
   test(`ZodContribSnakeToCamel`, () => {
     expectTypeOf<ZodContribSnakeToCamel<"foo_bar">>().toEqualTypeOf<"fooBar">();
-    expectTypeOf<ZodContribSnakeToCamel<"foo_bar_baz">>().toEqualTypeOf<"fooBarBaz">();
-    expectTypeOf<ZodContribSnakeToCamel<"foo_">>().toEqualTypeOf<"foo">();
-    expectTypeOf<ZodContribSnakeToCamel<"_foo">>().toEqualTypeOf<"_foo">();
-    expectTypeOf<ZodContribSnakeToCamel<"some_c$fé">>().toEqualTypeOf<"someC$fé">();
-  })
+    expectTypeOf<
+      ZodContribSnakeToCamel<"foo_bar_baz">
+    >().toEqualTypeOf<"fooBarBaz">();
+    expectTypeOf<ZodContribSnakeToCamel<"foo__">>().toEqualTypeOf<"foo__">();
+    expectTypeOf<ZodContribSnakeToCamel<"foo_">>().toEqualTypeOf<"foo_">();
+    expectTypeOf<ZodContribSnakeToCamel<"__foo_">>().toEqualTypeOf<"__foo_">();
+
+    expectTypeOf<ZodContribSnakeToCamel<"_">>().toBeNever();
+    expectTypeOf<ZodContribSnakeToCamel<"__">>().toBeNever();
+    expectTypeOf<ZodContribSnakeToCamel<"foo_bar__baz">>().toBeNever();
+    expectTypeOf<ZodContribSnakeToCamel<"foo__bar_baz">>().toBeNever();
+    expectTypeOf<ZodContribSnakeToCamel<"__ID_">>().toBeNever();
+    expectTypeOf<ZodContribSnakeToCamel<"foo__bar">>().toBeNever();
+    expectTypeOf<ZodContribSnakeToCamel<"fooBarBaz">>().toBeNever();
+    expectTypeOf<ZodContribSnakeToCamel<"ca_fé">>().toBeNever();
+    expectTypeOf<ZodContribSnakeToCamel<"c_$fé">>().toBeNever();
+    expectTypeOf<ZodContribSnakeToCamel<"some_c$fé">>().toBeNever();
+  });
 
   describe("ZodContribKeysToCamel", () => {
     test("simple object", () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,18 +1,78 @@
-export type ZodContribSnakeToCamelStep2<S extends string> =
+type AllowedLetters =
+  | "a"
+  | "b"
+  | "c"
+  | "d"
+  | "e"
+  | "f"
+  | "g"
+  | "h"
+  | "i"
+  | "j"
+  | "k"
+  | "l"
+  | "m"
+  | "n"
+  | "o"
+  | "p"
+  | "q"
+  | "r"
+  | "s"
+  | "t"
+  | "u"
+  | "v"
+  | "w"
+  | "x"
+  | "y"
+  | "z"
+  | "_";
+
+type OnlyChars<
+  O extends string,
+  Allowed extends string,
+  S extends string,
+> = S extends string
+  ? string extends S
+    ? S
+    : S extends ""
+      ? O
+      : S extends `${infer F}${infer R}`
+        ? F extends Allowed
+          ? OnlyChars<O, Allowed, R>
+          : never
+        : never
+  : never;
+
+export type OnlyAllowedChars<S extends string> = OnlyChars<
+  S,
+  AllowedLetters,
+  S
+>;
+
+// ==============
+export type DisallowMultipleUnderScores<S extends string> =
+  S extends `${infer _Head}__${infer _Tail}` ? never : S;
+
+// ===============
+export type AsCamelCase<S extends string> =
   S extends `${infer Head}_${infer Tail}`
-    ? `${Head}${Capitalize<ZodContribSnakeToCamelStep1<Tail>>}`
+    ? `${Head}${Capitalize<AsCamelCase<Tail>>}`
     : S;
 
-export type ZodContribSnakeToCamelStep1<S extends string> =
-  S extends `${infer Head}_`
-    ? `${ZodContribSnakeToCamel<Head>}_`
-    : ZodContribSnakeToCamelStep2<S>;
-
+// ===============
 export type ZodContribSnakeToCamel<S extends string> =
+  // Remove leading '_'
   S extends `_${infer Head}`
     ? `_${ZodContribSnakeToCamel<Head>}`
-    : ZodContribSnakeToCamelStep2<Lowercase<S>>;
+    : // Remove trailing '_'
+      S extends `${infer Head}_`
+      ? `${ZodContribSnakeToCamel<Head>}_`
+      : // If we've removed the underscores and left with "" error (never)
+        S extends ""
+        ? never
+        : AsCamelCase<OnlyAllowedChars<DisallowMultipleUnderScores<S>>>;
 
+// ===============
 export type ZodContribKeysToCamel<U> =
   U extends Array<infer V>
     ? Array<ZodContribKeysToCamel<V>>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,17 +1,17 @@
-// step 1: remove leading underscores
-export type ZodContribSnakeToCamelStep1<S extends string> =
-  S extends `_${infer Tail}`
-    ? ZodContribSnakeToCamelStep1<Tail>
-    : ZodContribSnakeToCamelStep2<S>;
-
-// step 1: snake_case -> camelCase
-type ZodContribSnakeToCamelStep2<S extends string> =
+export type ZodContribSnakeToCamelStep2<S extends string> =
   S extends `${infer Head}_${infer Tail}`
-    ? `${Head}${Capitalize<ZodContribSnakeToCamelStep2<Tail>>}`
+    ? `${Head}${Capitalize<ZodContribSnakeToCamelStep1<Tail>>}`
     : S;
 
+export type ZodContribSnakeToCamelStep1<S extends string> =
+  S extends `${infer Head}_`
+    ? `${ZodContribSnakeToCamel<Head>}_`
+    : ZodContribSnakeToCamelStep2<S>;
+
 export type ZodContribSnakeToCamel<S extends string> =
-  ZodContribSnakeToCamelStep1<S>;
+  S extends `_${infer Head}`
+    ? `_${ZodContribSnakeToCamel<Head>}`
+    : ZodContribSnakeToCamelStep2<Lowercase<S>>;
 
 export type ZodContribKeysToCamel<U> =
   U extends Array<infer V>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { ZodObject } from "zod";
+
 type AllowedLetters =
   | "a"
   | "b"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,4 +4,8 @@ export default {
     exclude: [],
     include: ["./src/**/*.test.ts"],
   },
+  typecheck: {
+    enabled: true,
+    include: ["./src/**/*.test.ts"],
+  },
 };


### PR DESCRIPTION
The conversion now keeps leading and trailing underscores for example `__foo_bar_baz___` becomes `__fooBarBaz___` this is because leading/trailing underscores often have special meaning.

There are some commented out tests in `./src/helpers/data.ts` which we'll work out what to do with in #10 