### PR TITLE
refactor: use Zod's own safeParse result type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { z, ZodError, ZodType } from "zod";
+import { z, ZodError, ZodSafeParseResult, ZodType } from "zod";
 import { keysToCamelCase, keysToSnakeCase } from "./format";
 import { ZodContribSnakeToCamel, ZodContribKeysToCamel } from "./types";
 import { rewriteErrorPathsToCamel } from "./error";
@@ -12,11 +12,7 @@ export type zodToCamelCaseOptions = { bidirectional?: boolean };
 type parse<Input, T> = (input: Input) => ZodContribKeysToCamel<z.infer<T>>;
 
 // safeParse(...) with optional `Input` type
-type safeParse<Input, T> = (input: Input) => {
-  success: boolean;
-  data?: ZodContribKeysToCamel<z.infer<T>>;
-  error?: any;
-};
+type safeParse<Input, T> = (input: Input) => ZodSafeParseResult<ZodContribKeysToCamel<z.infer<T>>>;
 
 // zodToCamelCase (unidirectional)
 export default function zodToCamelCase<T extends ZodType>(


### PR DESCRIPTION
This makes the type signature of the result of `zodToCamelCase` more closely match a "real" Zod schema. (Specifically, the real type uses `success` as a discriminant to type `data`/`error` more precisely.)

I encountered this when trying to pass a converted schema to a downstream library. The types weren't quite similar enough to work.