### PR TITLE
fix: copy `_zod` property to fix rare internal errors

### DIFF
--- a/src/error.test.ts
+++ b/src/error.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import { rewriteErrorPathsToCamel } from "./error";
 import { ZodError } from "zod";
+import { zodError } from "./test-utils";
 
 describe("rewriteErrorPathsToCamel", () => {
   test("basic", () => {
@@ -13,20 +14,14 @@ describe("rewriteErrorPathsToCamel", () => {
       },
     ]);
     const result = rewriteErrorPathsToCamel(error);
-    expect(result.message).toEqual(
-      JSON.stringify(
-        [
-          {
-            expected: "string",
-            code: "invalid_type",
-            path: ["keyOne"],
-            message: "Invalid input: expected string, received undefined",
-          },
-        ],
-        null,
-        2,
-      ),
-    );
+    expect(result.message).toEqual(zodError(
+      {
+        expected: "string",
+        code: "invalid_type",
+        path: ["keyOne"],
+        message: "Invalid input: expected string, received undefined",
+      },
+    ));
   });
 
   test("complex", () => {
@@ -39,19 +34,13 @@ describe("rewriteErrorPathsToCamel", () => {
       },
     ]);
     const result = rewriteErrorPathsToCamel(error);
-    expect(result.message).toEqual(
-      JSON.stringify(
-        [
-          {
-            expected: "string",
-            code: "invalid_type",
-            path: ["keyOne", 0, "somethingElse"],
-            message: "Invalid input: expected string, received undefined",
-          },
-        ],
-        null,
-        2,
-      ),
-    );
+    expect(result.message).toEqual(zodError(
+      {
+        expected: "string",
+        code: "invalid_type",
+        path: ["keyOne", 0, "somethingElse"],
+        message: "Invalid input: expected string, received undefined",
+      },
+    ));
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, expectTypeOf, test, it } from "vitest";
 
 import zodToCamelCase from "./";
 import { keysToCamelCase } from "./format";
+import { $ZodIssue } from "zod/v4/core";
 
 const complex_schema = z
   .object({
@@ -385,6 +386,157 @@ describe("zodToCamelCase (unidirectional)", () => {
 
     expect(camelSchema.parse(camelData)).toEqual(camelData);
   });
+
+  it("can be used in an array after conversion", () => {
+    // Note: Putting in an array AFTER converting to camel-case
+    const elementSchema = zodToCamelCase(
+      z.object({ element_name: z.string() })
+    );
+    const arraySchema = z.array(elementSchema);
+  
+    expect(arraySchema.parse(
+      [
+        { element_name: "a" },
+        { element_name: "b" },
+      ]
+    )).toEqual(
+      [
+        { elementName: "a" },
+        { elementName: "b" },
+      ]
+    );
+  });
+
+  it("has separate state when used multiple times", () => {
+    const schema = z.object({
+      key_one: z.string(),
+      key_two: z.string(),
+    });
+    const camelCase = zodToCamelCase(schema);
+
+    expect(camelCase.parse({
+      key_one: "abc",
+      key_two: "def",
+    })).toEqual({
+      keyOne: "abc",
+      keyTwo: "def",
+    });
+
+    expect(() =>
+      camelCase.parse({
+        key_one: "abc",
+        // @ts-expect-error
+        key_two: 2,
+      })
+    ).toThrow(
+      JSON.stringify(
+        [
+          {
+            expected: "string",
+            code: "invalid_type",
+            path: ["key_two"],
+            message: "Invalid input: expected string, received number",
+          },
+        ],
+        null,
+        2,
+      ),
+    );
+
+    expect(camelCase.parse({
+      key_one: "abc",
+      key_two: "def",
+    })).toEqual({
+      keyOne: "abc",
+      keyTwo: "def",
+    });
+
+    expect(() =>
+      camelCase.parse({
+        // @ts-expect-error
+        key_one: 2,
+        key_two: "def",
+      })
+    ).toThrow(
+      JSON.stringify(
+        [
+          {
+            expected: "string",
+            code: "invalid_type",
+            path: ["key_one"],
+            message: "Invalid input: expected string, received number",
+          },
+        ],
+        null,
+        2,
+      ),
+    );
+  });
+
+  it("has separate state to the original schema", () => {
+    const schema = z.object({
+      key_one: z.string(),
+      key_two: z.string(),
+    });
+    const camelCase = zodToCamelCase(schema);
+
+    expect(schema.parse({
+      key_one: "abc",
+      key_two: "def",
+    })).toEqual({
+      key_one: "abc",
+      key_two: "def",
+    });
+
+    expect(camelCase.parse({
+      key_one: "abc",
+      key_two: "def",
+    })).toEqual({
+      keyOne: "abc",
+      keyTwo: "def",
+    });
+
+    expect(() =>
+      schema.parse({
+        key_one: "abc",
+        key_two: 2,
+      })
+    ).toThrow(
+      JSON.stringify(
+        [
+          {
+            expected: "string",
+            code: "invalid_type",
+            path: ["key_two"],
+            message: "Invalid input: expected string, received number",
+          },
+        ],
+        null,
+        2,
+      ),
+    );
+
+    expect(() =>
+      camelCase.parse({
+        // @ts-expect-error
+        key_one: 2,
+        key_two: "def",
+      })
+    ).toThrow(
+      JSON.stringify(
+        [
+          {
+            expected: "string",
+            code: "invalid_type",
+            path: ["key_one"],
+            message: "Invalid input: expected string, received number",
+          },
+        ],
+        null,
+        2,
+      ),
+    );
+  });
 });
 
 describe("zodToCamelCase (bidirectional)", () => {
@@ -632,3 +784,10 @@ describe("zodToCamelCase (bidirectional)", () => {
     });
   });
 });
+
+// Helper to convert Zod issues into the error string thrown by Zod.
+function zodIssue(...issues: $ZodIssue[]): string {
+  return JSON.stringify([
+    ...issues
+  ]);
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, expectTypeOf, test, it } from "vitest";
 
 import zodToCamelCase from "./";
 import { keysToCamelCase } from "./format";
-import { $ZodIssue } from "zod/v4/core";
+import { zodError } from "./test-utils";
 
 const complex_schema = z
   .object({
@@ -122,20 +122,14 @@ describe("zodToCamelCase (unidirectional)", () => {
         key_two: "one",
       });
       expect(results.success).toEqual(false);
-      expect(results.error?.message).toEqual(
-        JSON.stringify(
-          [
-            {
-              expected: "string",
-              code: "invalid_type",
-              path: ["key_one"],
-              message: "Invalid input: expected string, received undefined",
-            },
-          ],
-          null,
-          2,
-        ),
-      );
+      expect(results.error?.message).toEqual(zodError(
+        {
+          expected: "string",
+          code: "invalid_type",
+          path: ["key_one"],
+          message: "Invalid input: expected string, received undefined",
+        },
+      ));
     });
 
     test("non-object schema", () => {
@@ -189,20 +183,14 @@ describe("zodToCamelCase (unidirectional)", () => {
           // @ts-expect-error
           key_two: "one",
         });
-      }).toThrow(
-        JSON.stringify(
-          [
-            {
-              expected: "string",
-              code: "invalid_type",
-              path: ["key_one"],
-              message: "Invalid input: expected string, received undefined",
-            },
-          ],
-          null,
-          2,
-        ),
-      );
+      }).toThrow(zodError(
+        {
+          expected: "string",
+          code: "invalid_type",
+          path: ["key_one"],
+          message: "Invalid input: expected string, received undefined",
+        },
+      ));
     });
 
     test("non parse error", () => {
@@ -428,20 +416,14 @@ describe("zodToCamelCase (unidirectional)", () => {
         // @ts-expect-error
         key_two: 2,
       })
-    ).toThrow(
-      JSON.stringify(
-        [
-          {
-            expected: "string",
-            code: "invalid_type",
-            path: ["key_two"],
-            message: "Invalid input: expected string, received number",
-          },
-        ],
-        null,
-        2,
-      ),
-    );
+    ).toThrow(zodError(
+      {
+        expected: "string",
+        code: "invalid_type",
+        path: ["key_two"],
+        message: "Invalid input: expected string, received number",
+      },
+    ));
 
     expect(camelCase.parse({
       key_one: "abc",
@@ -457,20 +439,14 @@ describe("zodToCamelCase (unidirectional)", () => {
         key_one: 2,
         key_two: "def",
       })
-    ).toThrow(
-      JSON.stringify(
-        [
-          {
-            expected: "string",
-            code: "invalid_type",
-            path: ["key_one"],
-            message: "Invalid input: expected string, received number",
-          },
-        ],
-        null,
-        2,
-      ),
-    );
+    ).toThrow(zodError(
+      {
+        expected: "string",
+        code: "invalid_type",
+        path: ["key_one"],
+        message: "Invalid input: expected string, received number",
+      },
+    ));
   });
 
   it("has separate state to the original schema", () => {
@@ -501,20 +477,14 @@ describe("zodToCamelCase (unidirectional)", () => {
         key_one: "abc",
         key_two: 2,
       })
-    ).toThrow(
-      JSON.stringify(
-        [
-          {
-            expected: "string",
-            code: "invalid_type",
-            path: ["key_two"],
-            message: "Invalid input: expected string, received number",
-          },
-        ],
-        null,
-        2,
-      ),
-    );
+    ).toThrow(zodError(
+      {
+        expected: "string",
+        code: "invalid_type",
+        path: ["key_two"],
+        message: "Invalid input: expected string, received number",
+      },
+    ));
 
     expect(() =>
       camelCase.parse({
@@ -522,20 +492,14 @@ describe("zodToCamelCase (unidirectional)", () => {
         key_one: 2,
         key_two: "def",
       })
-    ).toThrow(
-      JSON.stringify(
-        [
-          {
-            expected: "string",
-            code: "invalid_type",
-            path: ["key_one"],
-            message: "Invalid input: expected string, received number",
-          },
-        ],
-        null,
-        2,
-      ),
-    );
+    ).toThrow(zodError(
+      {
+        expected: "string",
+        code: "invalid_type",
+        path: ["key_one"],
+        message: "Invalid input: expected string, received number",
+      },
+    ));
   });
 });
 
@@ -671,20 +635,14 @@ describe("zodToCamelCase (bidirectional)", () => {
         keyTwo: "one",
       });
       expect(results.success).toEqual(false);
-      expect(results.error?.message).toEqual(
-        JSON.stringify(
-          [
-            {
-              expected: "string",
-              code: "invalid_type",
-              path: ["keyOne"],
-              message: "Invalid input: expected string, received undefined",
-            },
-          ],
-          null,
-          2,
-        ),
-      );
+      expect(results.error?.message).toEqual(zodError(
+        {
+          expected: "string",
+          code: "invalid_type",
+          path: ["keyOne"],
+          message: "Invalid input: expected string, received undefined",
+        },
+      ));
     });
 
     test("non-object schema", () => {
@@ -738,20 +696,14 @@ describe("zodToCamelCase (bidirectional)", () => {
           // @ts-expect-error
           keyTwo: "one",
         });
-      }).toThrow(
-        JSON.stringify(
-          [
-            {
-              expected: "string",
-              code: "invalid_type",
-              path: ["keyOne"],
-              message: "Invalid input: expected string, received undefined",
-            },
-          ],
-          null,
-          2,
-        ),
-      );
+      }).toThrow(zodError(
+        {
+          expected: "string",
+          code: "invalid_type",
+          path: ["keyOne"],
+          message: "Invalid input: expected string, received undefined",
+        },
+      ));
     });
 
     test("non parse error", () => {
@@ -785,9 +737,3 @@ describe("zodToCamelCase (bidirectional)", () => {
   });
 });
 
-// Helper to convert Zod issues into the error string thrown by Zod.
-function zodIssue(...issues: $ZodIssue[]): string {
-  return JSON.stringify([
-    ...issues
-  ]);
-}

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,11 @@ export default function zodToCamelCase<T extends ZodType>(
 
   return {
     ...newSchema,
+
+    // This is a non-enumerable property so doesn't get copied by default, but is required by the
+    // internals of Zod.
+    _zod: newSchema._zod,
+    
     parse: (
       input: ZodContribKeysToCamel<z.infer<T>> | z.infer<T>,
     ): ZodContribKeysToCamel<z.infer<T>> => {

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -1,0 +1,12 @@
+import { $ZodIssue } from "zod/v4/core";
+
+/**
+ * Convert Zod issues into the error string that will be thrown by Zod for those issues.
+ */
+export function zodError(...issues: $ZodIssue[]): string {
+  return JSON.stringify(
+    issues,
+    null,
+    2,
+  );
+}


### PR DESCRIPTION
This property contains some Zod implementation details.
It's non-enumerable so doesn't get copied by the spread operator.

With this property missing, using `z.array` on a converted schema gave an error when some internal Zod code tried to call `._zod.run()`. I've added a test for this specific case. This seemed to be the only problem caused by `_zod` missing in oaknational/studio.

As @orangemug suggested, I've also added a couple of tests for niche cases - such as using a schema multiple times - in case this object contained some kind of ephemeral state which we couldn't share.
These tests passed without issues so that doesn't seem to be the case.

This involved adding some new erroring cases, so I've also broken out a test helper to make describing the expected issue a little more concise.