### PR TITLE
feat: statically-type `keysToCamelCase`

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -1,3 +1,5 @@
+import { ZodContribKeysToCamel } from "./types";
+
 export const camelToSnakeCase = (str: string) =>
   str.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
 
@@ -20,15 +22,15 @@ export const snakeToCamelCase = (str: string) => {
   });
 };
 
-export function keysToCamelCase<T>(obj: T): any {
-  if (Array.isArray(obj)) return obj.map(keysToCamelCase);
+export function keysToCamelCase<T>(obj: T): ZodContribKeysToCamel<T> {
+  if (Array.isArray(obj)) return obj.map(keysToCamelCase) as ZodContribKeysToCamel<T>;
   if (obj !== null && typeof obj === "object") {
     return Object.fromEntries(
       Object.entries(obj).map(([k, v]) => [
         snakeToCamelCase(k),
         keysToCamelCase(v),
       ]),
-    );
+    ) as ZodContribKeysToCamel<T>;
   }
-  return obj;
+  return obj as ZodContribKeysToCamel<T>;
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -308,7 +308,7 @@ describe("zodToCamelCase (unidirectional)", () => {
     const unionSchema = zodToCamelCase(union_schema);
 
     const simple_item = {
-      type: "simple",
+      type: "simple" as const,
       url: "https://example.com/simple_image.png",
       size: 12345,
     };
@@ -364,7 +364,7 @@ describe("zodToCamelCase (unidirectional)", () => {
   it("can convert a tuple schema", () => {
     const tupleSchema = z.tuple([z.string(), z.number()]);
 
-    const data = ["test", 123];
+    const data: [string, number] = ["test", 123];
 
     expect(tupleSchema.parse(data)).toEqual(data);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ export default function zodToCamelCase<T extends ZodType>(
       return input;
     }, schema)
     .transform(
-      (data) => keysToCamelCase(data) as ZodContribKeysToCamel<z.infer<T>>,
+      (data) => keysToCamelCase(data),
     );
 
   return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,12 +35,21 @@ export type ZodContribSnakeToCamel<S extends string> =
     : never;
 
 export type ZodContribKeysToCamel<U> =
-  U extends Array<infer V>
-    ? Array<ZodContribKeysToCamel<V>>
-    : U extends object
-      ? {
-          [K in keyof U as ZodContribSnakeToCamel<
-            string & K
-          >]: ZodContribKeysToCamel<U[K]>;
-        }
-      : U;
+  // Empty tuple
+  U extends []
+    ? []
+    // Non-empty tuple
+    : U extends [infer Head, ...infer Tail]
+      ? [ZodContribKeysToCamel<Head>, ...ZodContribKeysToCamel<Tail>]
+      // Array
+      : U extends Array<infer V>
+        ? Array<ZodContribKeysToCamel<V>>
+        // Object
+        : U extends object
+          ? {
+              [K in keyof U as ZodContribSnakeToCamel<
+                string & K
+              >]: ZodContribKeysToCamel<U[K]>;
+            }
+          // Anything else
+          : U;


### PR DESCRIPTION
Reuse the `ZodContribKeysToCamel` type to statically-type the return value of `keysToCamelCase`.

We use this in the Studio repo quite a bit, and our existing internal implementation is typed, so this makes it a more suitable drop-in replacement.

----

Only a couple of tests needed minor tweaks due to stricter type-checking.

To reduce the number of changes needed to the `"can convert a tuple schema"` test, I added logic to `ZodContribKeysToCamel` to also convert tuples. Previously, they degraded to an array of unions, now they stay as a tuple. This feels like a useful general improvement too, not just to make the test work :)

```ts
type X = ZodContribKeysToCamel<[ { a_b: string }, { b_c: number } ]>;

// Without new tuple case, this evaluated to:
type X = ( { aB: string } | { bC: number } )[];

// With new tuple case:
type X = [ { ab: String }, { bC: number } ];
```